### PR TITLE
fix: convert inline code to use InlineCode macro so italics work

### DIFF
--- a/typeset/drvmly.ltx
+++ b/typeset/drvmly.ltx
@@ -51,6 +51,7 @@
 \usepackage{microtype}
 \usepackage{hyperref}
 \usepackage{amsmath}
+\newcommand{\InlineCode}[1]{\texttt{#1}}
 
 \makeatletter
 

--- a/typeset/drvpst.ltx
+++ b/typeset/drvpst.ltx
@@ -49,6 +49,7 @@
 \usepackage{microtype}
 \usepackage{hyperref}
 \usepackage{amsmath}
+\newcommand{\InlineCode}[1]{\texttt{#1}}
 
 \makeatletter
 

--- a/typeset/md2tex.c
+++ b/typeset/md2tex.c
@@ -289,11 +289,7 @@ static int enter_span_calback(MD_SPANTYPE type, void *detail, void *userdata) {
     render_open_img_span(r, (MD_SPAN_IMG_DETAIL *)detail);
     break;
   case MD_SPAN_CODE:
-    if (r->heading_scope == 0) {
-      RENDER_VERBATIM(r, "\\verb!");
-      r->verbatim_type = 2;
-    } else
-      RENDER_VERBATIM(r, "\\texttt{");
+    RENDER_VERBATIM(r, "\\InlineCode{");
     break;
   case MD_SPAN_DEL:
     RENDER_VERBATIM(r, "\\del{");
@@ -331,11 +327,7 @@ static int leave_span_calback(MD_SPANTYPE type, void *detail, void *userdata) {
     render_close_img_span(r, (MD_SPAN_IMG_DETAIL *)detail);
     break;
   case MD_SPAN_CODE:
-    if (r->heading_scope == 0) {
-      RENDER_VERBATIM(r, "!");
-      r->verbatim_type = 0;
-    } else
-      RENDER_VERBATIM(r, "}");
+    RENDER_VERBATIM(r, "}");
     break;
   case MD_SPAN_DEL:
     RENDER_VERBATIM(r, "}");


### PR DESCRIPTION
## Summary
- add `InlineCode` macro in latex templates
- convert inline code to use InlineCode macro so italics work

## Testing
- `pnpm run lint` *(fails: ESLint couldn't find config)*
- `python3 scripts/make.py post`


------
https://chatgpt.com/codex/tasks/task_e_6843e3a34678832083835ad1611689e5