### PR TITLE
feat: add compilations page listing PDF batches

### DIFF
--- a/src/components/BatchCard.astro
+++ b/src/components/BatchCard.astro
@@ -1,0 +1,44 @@
+---
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  id: number;
+  pdf: string;
+  posts: CollectionEntry<"blog">[];
+}
+
+const { id, pdf, posts } = Astro.props as Props;
+---
+<a href={pdf} class="group block overflow-hidden rounded-lg border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 transition-colors duration-300 ease-in-out">
+  <canvas id={`preview-${id}`} class="w-full h-48 object-cover bg-black/5 dark:bg-white/10" />
+  <div class="p-4 space-y-2">
+    <div class="font-semibold">Batch #{id}</div>
+    <ul class="text-sm list-disc list-inside space-y-0.5">
+      {posts.map((p) => (
+        <li>{p.data.title}</li>
+      ))}
+    </ul>
+  </div>
+</a>
+
+<script type="module" is:inline>
+  const pdfUrl = "${pdf}";
+  const canvasId = "preview-${id}";
+  import("https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/+esm").then((pdfjsLib) => {
+    pdfjsLib.GlobalWorkerOptions.workerSrc =
+      "https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js";
+    const canvas = document.getElementById(canvasId);
+    if (!canvas) return;
+    pdfjsLib.getDocument(pdfUrl).promise.then((pdfDoc) => {
+      pdfDoc.getPage(1).then((page) => {
+        const viewport = page.getViewport({ scale: 1 });
+        const scale = canvas.clientWidth / viewport.width;
+        const scaledViewport = page.getViewport({ scale });
+        canvas.width = scaledViewport.width;
+        canvas.height = scaledViewport.height;
+        const context = canvas.getContext("2d");
+        page.render({ canvasContext: context, viewport: scaledViewport });
+      });
+    });
+  });
+</script>

--- a/src/components/BatchCard.astro
+++ b/src/components/BatchCard.astro
@@ -10,15 +10,25 @@ interface Props {
 
 const { id, pdf, posts, hash } = Astro.props as Props;
 
-const color1 = `#${hash.slice(0, 6)}`;
-const color2 = `#${(parseInt(hash.slice(0, 6), 16) ^ 0xffffff)
-  .toString(16)
-  .padStart(6, "0")}`;
+const color1 = `#${hash.slice(0, 3)}`;
+const color2 = `#${hash.slice(3, 6)}`;
 ---
-<a href={pdf} class="group block overflow-hidden rounded-lg border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 transition-colors duration-300 ease-in-out">
-  <div class="w-full h-48" style={`background: linear-gradient(135deg, ${color1}, ${color2});`}></div>
+<a
+  href={pdf}
+  target="_blank"
+  class="group relative block overflow-hidden rounded-lg border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 transition-colors duration-300 ease-in-out">
+  <div class="relative w-full h-48" style={`background: linear-gradient(135deg, ${color1}, ${color2});`}>
+    <div class="absolute inset-0 grid place-items-center font-mono text-2xl text-black dark:text-white">
+      Batch #{id}
+    </div>
+  </div>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    class="absolute top-2 right-2 size-5 stroke-2 fill-none stroke-current opacity-80">
+    <path d="M14 5h5m0 0v5m0-5L10 19" />
+  </svg>
   <div class="p-4 space-y-2">
-    <div class="font-semibold">Batch #{id}</div>
     <ul class="text-sm list-disc list-inside space-y-0.5">
       {posts.map((p) => (
         <li>{p.data.title}</li>

--- a/src/components/BatchCard.astro
+++ b/src/components/BatchCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { createHash } from "node:crypto";
 
 interface Props {
   id: number;
@@ -10,28 +11,36 @@ interface Props {
 
 const { id, pdf, posts, hash } = Astro.props as Props;
 
-// generate a near-gray hue derived from the hash so every batch has a slightly
-// different colour
-const hue = (parseInt(hash.slice(0, 2), 16) / 255) * 360;
-const light = 40 + (parseInt(hash.slice(2, 4), 16) % 50);
-const color = `hsl(${hue.toFixed(0)}, 20%, ${light}%)`;
+const longHash = createHash("sha256").update(hash).digest("hex");
 
-// build a 25x15 pixel art grid, mirroring horizontally
+// generate a near-gray hue derived from the hash so every batch has a slightly
+// different colour. keep saturation low and lightness high
+const hue = (parseInt(longHash.slice(0, 2), 16) / 255) * 360;
+const light = 80 + (parseInt(longHash.slice(2, 4), 16) % 15); // 80-94
+const color = `hsl(${hue.toFixed(0)}, 10%, ${light}%)`;
+
+// build a 25x15 pixel art grid using the long hash for randomness
 const width = 25;
 const height = 15;
 const coords: { x: number; y: number }[] = [];
 let i = 0;
 for (let y = 0; y < height; y++) {
-  for (let x = 0; x < Math.ceil(width / 2); x++, i++) {
-    if (parseInt(hash[i % hash.length], 16) % 2 === 1) {
+  for (let x = 0; x < width; x++, i++) {
+    if (parseInt(longHash[i % longHash.length], 16) % 2 === 1) {
       coords.push({ x, y });
-      const mirror = width - 1 - x;
-      if (mirror !== x) coords.push({ x: mirror, y });
     }
   }
 }
 
-const date = posts[0]?.data.date ?? "";
+const date = posts[0]?.data.date;
+const dateStr = date
+  ? date.toLocaleDateString("en-US", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    })
+  : "";
+const info = `${dateStr} (${hash})`;
 ---
 <a
   href={pdf}
@@ -42,16 +51,15 @@ const date = posts[0]?.data.date ?? "";
     <svg
       viewBox="0 0 375 225"
       preserveAspectRatio="none"
-      class="w-full h-full"
+      class="w-full h-full dark:invert"
     >
       {coords.map(({ x, y }) => (
         <rect x={x * 15} y={y * 15} width="15" height="15" fill={color} />
       ))}
     </svg>
-    <div class="absolute inset-0 flex flex-col items-center justify-center font-mono text-black dark:text-white">
-      <div class="font-bold text-3xl sm:text-4xl">Batch #{id}</div>
-      <div class="text-xs sm:text-sm">{date}</div>
-      <div class="text-xs sm:text-sm">{hash}</div>
+    <div class="absolute inset-0 flex flex-col items-center justify-center font-mono text-black dark:text-white text-center">
+      <div class="font-bold text-3xl sm:text-4xl mb-1">Batch #{id}</div>
+      <div class="text-xs sm:text-sm">{info}</div>
     </div>
   </div>
   <svg

--- a/src/components/BatchCard.astro
+++ b/src/components/BatchCard.astro
@@ -10,23 +10,42 @@ interface Props {
 
 const { id, pdf, posts, hash } = Astro.props as Props;
 
-const color1 = `#${hash.slice(0, 3)}`;
-const color2 = `#${hash.slice(3, 6)}`;
+// generate a near-gray color derived from the hash
+const gray = 40 + (parseInt(hash.slice(0, 2), 16) % 50);
+const color = `hsl(0, 0%, ${gray}%)`;
+
+// create symmetric 5x5 pixel art similar to GitHub identicons
+const coords: { x: number; y: number }[] = [];
+let i = 0;
+for (let y = 0; y < 5; y++) {
+  for (let x = 0; x < 3; x++, i++) {
+    if (parseInt(hash[i], 16) % 2 === 1) {
+      coords.push({ x, y });
+      if (x !== 2) coords.push({ x: 4 - x, y });
+    }
+  }
+}
 ---
 <a
   href={pdf}
   target="_blank"
+  rel="noopener noreferrer"
   class="group relative block overflow-hidden rounded-lg border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 transition-colors duration-300 ease-in-out">
-  <div class="relative w-full h-48" style={`background: linear-gradient(135deg, ${color1}, ${color2});`}>
-    <div class="absolute inset-0 grid place-items-center font-mono text-2xl text-black dark:text-white">
+  <div class="relative w-full h-48 bg-black/5 dark:bg-white/10">
+    <svg viewBox="0 0 100 100" class="w-full h-full">
+      {coords.map(({ x, y }) => (
+        <rect x={x * 20} y={y * 20} width="20" height="20" fill={color} />
+      ))}
+    </svg>
+    <div class="absolute inset-0 grid place-items-center font-mono text-3xl sm:text-4xl text-black dark:text-white">
       Batch #{id}
     </div>
   </div>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    class="absolute top-2 right-2 size-5 stroke-2 fill-none stroke-current opacity-80">
-    <path d="M14 5h5m0 0v5m0-5L10 19" />
+    viewBox="0 0 512 512"
+    class="absolute top-2 right-2 size-5 stroke-0 fill-current opacity-80">
+    <path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z" />
   </svg>
   <div class="p-4 space-y-2">
     <ul class="text-sm list-disc list-inside space-y-0.5">

--- a/src/components/BatchCard.astro
+++ b/src/components/BatchCard.astro
@@ -5,12 +5,18 @@ interface Props {
   id: number;
   pdf: string;
   posts: CollectionEntry<"blog">[];
+  hash: string;
 }
 
-const { id, pdf, posts } = Astro.props as Props;
+const { id, pdf, posts, hash } = Astro.props as Props;
+
+const color1 = `#${hash.slice(0, 6)}`;
+const color2 = `#${(parseInt(hash.slice(0, 6), 16) ^ 0xffffff)
+  .toString(16)
+  .padStart(6, "0")}`;
 ---
 <a href={pdf} class="group block overflow-hidden rounded-lg border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 transition-colors duration-300 ease-in-out">
-  <canvas id={`preview-${id}`} class="w-full h-48 object-cover bg-black/5 dark:bg-white/10" />
+  <div class="w-full h-48" style={`background: linear-gradient(135deg, ${color1}, ${color2});`}></div>
   <div class="p-4 space-y-2">
     <div class="font-semibold">Batch #{id}</div>
     <ul class="text-sm list-disc list-inside space-y-0.5">
@@ -20,25 +26,3 @@ const { id, pdf, posts } = Astro.props as Props;
     </ul>
   </div>
 </a>
-
-<script type="module" is:inline>
-  const pdfUrl = "${pdf}";
-  const canvasId = "preview-${id}";
-  import("https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/+esm").then((pdfjsLib) => {
-    pdfjsLib.GlobalWorkerOptions.workerSrc =
-      "https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js";
-    const canvas = document.getElementById(canvasId);
-    if (!canvas) return;
-    pdfjsLib.getDocument(pdfUrl).promise.then((pdfDoc) => {
-      pdfDoc.getPage(1).then((page) => {
-        const viewport = page.getViewport({ scale: 1 });
-        const scale = canvas.clientWidth / viewport.width;
-        const scaledViewport = page.getViewport({ scale });
-        canvas.width = scaledViewport.width;
-        canvas.height = scaledViewport.height;
-        const context = canvas.getContext("2d");
-        page.render({ canvasContext: context, viewport: scaledViewport });
-      });
-    });
-  });
-</script>

--- a/src/components/BatchCard.astro
+++ b/src/components/BatchCard.astro
@@ -10,21 +10,28 @@ interface Props {
 
 const { id, pdf, posts, hash } = Astro.props as Props;
 
-// generate a near-gray color derived from the hash
-const gray = 40 + (parseInt(hash.slice(0, 2), 16) % 50);
-const color = `hsl(0, 0%, ${gray}%)`;
+// generate a near-gray hue derived from the hash so every batch has a slightly
+// different colour
+const hue = (parseInt(hash.slice(0, 2), 16) / 255) * 360;
+const light = 40 + (parseInt(hash.slice(2, 4), 16) % 50);
+const color = `hsl(${hue.toFixed(0)}, 20%, ${light}%)`;
 
-// create symmetric 5x5 pixel art similar to GitHub identicons
+// build a 25x15 pixel art grid, mirroring horizontally
+const width = 25;
+const height = 15;
 const coords: { x: number; y: number }[] = [];
 let i = 0;
-for (let y = 0; y < 5; y++) {
-  for (let x = 0; x < 3; x++, i++) {
-    if (parseInt(hash[i], 16) % 2 === 1) {
+for (let y = 0; y < height; y++) {
+  for (let x = 0; x < Math.ceil(width / 2); x++, i++) {
+    if (parseInt(hash[i % hash.length], 16) % 2 === 1) {
       coords.push({ x, y });
-      if (x !== 2) coords.push({ x: 4 - x, y });
+      const mirror = width - 1 - x;
+      if (mirror !== x) coords.push({ x: mirror, y });
     }
   }
 }
+
+const date = posts[0]?.data.date ?? "";
 ---
 <a
   href={pdf}
@@ -32,20 +39,34 @@ for (let y = 0; y < 5; y++) {
   rel="noopener noreferrer"
   class="group relative block overflow-hidden rounded-lg border border-black/15 dark:border-white/20 hover:bg-black/5 dark:hover:bg-white/5 transition-colors duration-300 ease-in-out">
   <div class="relative w-full h-48 bg-black/5 dark:bg-white/10">
-    <svg viewBox="0 0 100 100" class="w-full h-full">
+    <svg
+      viewBox="0 0 375 225"
+      preserveAspectRatio="none"
+      class="w-full h-full"
+    >
       {coords.map(({ x, y }) => (
-        <rect x={x * 20} y={y * 20} width="20" height="20" fill={color} />
+        <rect x={x * 15} y={y * 15} width="15" height="15" fill={color} />
       ))}
     </svg>
-    <div class="absolute inset-0 grid place-items-center font-mono text-3xl sm:text-4xl text-black dark:text-white">
-      Batch #{id}
+    <div class="absolute inset-0 flex flex-col items-center justify-center font-mono text-black dark:text-white">
+      <div class="font-bold text-3xl sm:text-4xl">Batch #{id}</div>
+      <div class="text-xs sm:text-sm">{date}</div>
+      <div class="text-xs sm:text-sm">{hash}</div>
     </div>
   </div>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 512 512"
-    class="absolute top-2 right-2 size-5 stroke-0 fill-current opacity-80">
-    <path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112v320c0 44.2 35.8 80 80 80h320c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v112c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16h112c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z" />
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="absolute top-2 right-2 size-5 opacity-80"
+  >
+    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    <polyline points="15 3 21 3 21 9" />
+    <line x1="10" y1="14" x2="21" y2="3" />
   </svg>
   <div class="p-4 space-y-2">
     <ul class="text-sm list-disc list-inside space-y-0.5">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,6 +18,12 @@ import Link from "@components/Link.astro";
         <span>
           {`/`}
         </span>
+        <Link href="/batch">
+          Compilations
+        </Link>
+        <span>
+          {`/`}
+        </span>
         <Link href="https://github.com/Computerization" aria-label="Computerization on GitHub" external>
           GitHub
         </Link>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -17,3 +17,8 @@ export const BLOG: Metadata = {
   TITLE: "Blog",
   DESCRIPTION: "A collection of articles on computer science and technology.",
 };
+
+export const BATCH: Metadata = {
+  TITLE: "Compilations",
+  DESCRIPTION: "Download compiled newsletters in PDF batches.",
+};

--- a/src/pages/batch/index.astro
+++ b/src/pages/batch/index.astro
@@ -16,13 +16,15 @@ const blog = (await getCollection("blog"))
 
 const batches = pdfFiles
   .map((file) => {
-    const [, idStr] = file.split("_");
+    const [, idStr, hashWithExt] = file.split("_");
     const id = parseInt(idStr, 10);
+    const hash = hashWithExt.replace(/\.pdf$/, "");
     const posts = blog.slice(id * 5, id * 5 + 5);
     return {
       id,
       pdf: `/batch/${file}`,
       posts,
+      hash,
     };
   })
   .sort((a, b) => b.id - a.id);
@@ -43,7 +45,7 @@ const batches = pdfFiles
       </section>
       <div class="grid gap-6 md:grid-cols-2">
         {batches.map((batch) => (
-          <BatchCard id={batch.id} pdf={batch.pdf} posts={batch.posts} />
+          <BatchCard id={batch.id} pdf={batch.pdf} posts={batch.posts} hash={batch.hash} />
         ))}
       </div>
     </div>

--- a/src/pages/batch/index.astro
+++ b/src/pages/batch/index.astro
@@ -1,0 +1,51 @@
+---
+import fs from "node:fs";
+import path from "node:path";
+import { getCollection } from "astro:content";
+import PageLayout from "@layouts/PageLayout.astro";
+import Container from "@components/Container.astro";
+import BatchCard from "@components/BatchCard.astro";
+import { BATCH } from "@consts";
+
+const pdfDir = path.resolve("./public/batch");
+const pdfFiles = fs.readdirSync(pdfDir).filter((f) => f.endsWith(".pdf"));
+
+const blog = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
+
+const batches = pdfFiles
+  .map((file) => {
+    const [, idStr] = file.split("_");
+    const id = parseInt(idStr, 10);
+    const posts = blog.slice(id * 5, id * 5 + 5);
+    return {
+      id,
+      pdf: `/batch/${file}`,
+      posts,
+    };
+  })
+  .sort((a, b) => b.id - a.id);
+---
+<PageLayout title={BATCH.TITLE} description={BATCH.DESCRIPTION}>
+  <Container>
+    <div class="space-y-8">
+      <section class="animate space-y-4">
+        <h5 class="font-semibold text-black dark:text-white">
+          {BATCH.TITLE}
+        </h5>
+        <article>
+          <p>
+            Browse compiled newsletters. Each compilation contains five posts in
+            chronological order.
+          </p>
+        </article>
+      </section>
+      <div class="grid gap-6 md:grid-cols-2">
+        {batches.map((batch) => (
+          <BatchCard id={batch.id} pdf={batch.pdf} posts={batch.posts} />
+        ))}
+      </div>
+    </div>
+  </Container>
+</PageLayout>


### PR DESCRIPTION
## Summary

- Created a BatchCard component that generates a 25×15 pixel identicon from a SHA‑256 hash with low saturation and lightness, overlaying the batch number, date, and hash, with a link icon in the corner
- Added a “Compilations” link to the header navigation
- Defined BATCH page metadata in consts.ts
- Implemented a new page that lists PDF batches found in /public/batch and displays them using BatchCard

## Testing

- :x: pnpm run lint (failed: missing dependencies)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.