### PR TITLE
Fix malformed blog frontmatter titles

### DIFF
--- a/src/content/blog/2025-08-10/index.md
+++ b/src/content/blog/2025-08-10/index.md
@@ -1,5 +1,5 @@
 ---
-title: ""深入理解并实现基本的基数树（Radix Tree）数据结构""
+title: "深入理解并实现基本的基数树（Radix Tree）数据结构"
 author: "王思成"
 date: "Aug 10, 2025"
 description: "深入解析基数树原理与实现"

--- a/src/content/blog/2025-08-12/index.md
+++ b/src/content/blog/2025-08-12/index.md
@@ -1,5 +1,5 @@
 ---
-title: ""深入理解并实现基本的布谷鸟哈希（Cuckoo Hashing）数据结构""
+title: "深入理解并实现基本的布谷鸟哈希（Cuckoo Hashing）数据结构"
 author: "黄梓淳"
 date: "Aug 12, 2025"
 description: "深入解析布谷鸟哈希原理与实现"


### PR DESCRIPTION
## Summary
- fix malformed YAML frontmatter title quotes in the Aug 10 and Aug 12 2025 blog posts
- ensure content collection parsing succeeds during the Astro build

## Testing
- pnpm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4cdf4cac83208eb92b4fe58aec64)