### PR TITLE
Remove '基本的' prefix from blog titles

### DIFF
--- a/src/content/blog/2025-05-03/index.md
+++ b/src/content/blog/2025-05-03/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的哈希表数据结构"
+title: "哈希表数据结构"
 author: "杨其臻"
 date: "May 03, 2025"
 description: "深入解析哈希表原理与实现"

--- a/src/content/blog/2025-05-06/index.md
+++ b/src/content/blog/2025-05-06/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的红黑树数据结构"
+title: "红黑树数据结构"
 author: "黄京"
 date: "May 06, 2025"
 description: "红黑树原理与实现详解"

--- a/src/content/blog/2025-05-08/index.md
+++ b/src/content/blog/2025-05-08/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 B 树数据结构"
+title: "B 树数据结构"
 author: "杨其臻"
 date: "May 08, 2025"
 description: "B 树原理与 Python 实现详解"

--- a/src/content/blog/2025-05-13/index.md
+++ b/src/content/blog/2025-05-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的跳表（Skip List）数据结构"
+title: "跳表（Skip List）数据结构"
 author: "叶家炜"
 date: "May 13, 2025"
 description: "跳表数据结构原理与 Python 实现"

--- a/src/content/blog/2025-06-04/index.md
+++ b/src/content/blog/2025-06-04/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的布隆过滤器(Bloom Filter)数据结构"
+title: "布隆过滤器(Bloom Filter)数据结构"
 author: "叶家炜"
 date: "Jun 04, 2025"
 description: "深入解析布隆过滤器原理与实现"

--- a/src/content/blog/2025-06-05/index.md
+++ b/src/content/blog/2025-06-05/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数树（Radix Tree）数据结构"
+title: "基数树（Radix Tree）数据结构"
 author: "杨其臻"
 date: "Jun 05, 2025"
 description: "深入解析基数树原理与实现"

--- a/src/content/blog/2025-06-14/index.md
+++ b/src/content/blog/2025-06-14/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 AVL 树数据结构"
+title: "AVL 树数据结构"
 author: "杨子凡"
 date: "Jun 14, 2025"
 description: "深入解析 AVL 树原理与实现"

--- a/src/content/blog/2025-06-23/index.md
+++ b/src/content/blog/2025-06-23/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的优先队列（Priority Queue）数据结构"
+title: "优先队列（Priority Queue）数据结构"
 author: "黄京"
 date: "Jun 23, 2025"
 description: "深入解析优先队列的原理与二叉堆实现"

--- a/src/content/blog/2025-06-25/index.md
+++ b/src/content/blog/2025-06-25/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 B+ 树数据结构"
+title: "B+ 树数据结构"
 author: "杨其臻"
 date: "Jun 25, 2025"
 description: "B+ 树数据结构详解与代码实现"

--- a/src/content/blog/2025-07-01/index.md
+++ b/src/content/blog/2025-07-01/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的双端队列（Deque）数据结构"
+title: "双端队列（Deque）数据结构"
 author: "叶家炜"
 date: "Jul 01, 2025"
 description: "深入解析双端队列（Deque）的实现与应用"

--- a/src/content/blog/2025-07-06/index.md
+++ b/src/content/blog/2025-07-06/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的线段树（Segment Tree）数据结构"
+title: "线段树（Segment Tree）数据结构"
 author: "黄京"
 date: "Jul 06, 2025"
 description: "深入解析线段树数据结构原理与实现"

--- a/src/content/blog/2025-07-13/index.md
+++ b/src/content/blog/2025-07-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的循环缓冲区（Circular Buffer）数据结构"
+title: "循环缓冲区（Circular Buffer）数据结构"
 author: "黄京"
 date: "Jul 13, 2025"
 description: "深入解析循环缓冲区的实现原理与优化技巧"

--- a/src/content/blog/2025-07-19/index.md
+++ b/src/content/blog/2025-07-19/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的红黑树数据结构"
+title: "红黑树数据结构"
 author: "杨子凡"
 date: "Jul 19, 2025"
 description: "红黑树原理与实现详解"

--- a/src/content/blog/2025-07-21/index.md
+++ b/src/content/blog/2025-07-21/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的斐波那契堆"
+title: "斐波那契堆"
 author: "杨其臻"
 date: "Jul 21, 2025"
 description: "斐波那契堆原理与实现详解"

--- a/src/content/blog/2025-07-23/index.md
+++ b/src/content/blog/2025-07-23/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的图（Graph）数据结构"
+title: "图（Graph）数据结构"
 author: "杨其臻"
 date: "Jul 23, 2025"
 description: "图数据结构从理论到代码实践详解"

--- a/src/content/blog/2025-07-24/index.md
+++ b/src/content/blog/2025-07-24/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的位图（Bitmap）数据结构"
+title: "位图（Bitmap）数据结构"
 author: "黄京"
 date: "Jul 24, 2025"
 description: "深入解析位图数据结构原理与实现"

--- a/src/content/blog/2025-07-25/index.md
+++ b/src/content/blog/2025-07-25/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的并查集（Disjoint Set Union）数据结构"
+title: "并查集（Disjoint Set Union）数据结构"
 author: "黄京"
 date: "Jul 25, 2025"
 description: "深入解析并查集原理与优化实现"

--- a/src/content/blog/2025-07-28/index.md
+++ b/src/content/blog/2025-07-28/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的二叉平衡树（Balanced Binary Tree）数据结构"
+title: "二叉平衡树（Balanced Binary Tree）数据结构"
 author: "叶家炜"
 date: "Jul 28, 2025"
 description: "深入解析 AVL 树的实现原理与旋转操作"

--- a/src/content/blog/2025-07-29/index.md
+++ b/src/content/blog/2025-07-29/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 K-d 树数据结构"
+title: "K-d 树数据结构"
 author: "杨子凡"
 date: "Jul 29, 2025"
 description: "深入解析 K-d 树数据结构与实现"

--- a/src/content/blog/2025-08-01/index.md
+++ b/src/content/blog/2025-08-01/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的图着色（Graph Coloring）算法"
+title: "图着色（Graph Coloring）算法"
 author: "杨其臻"
 date: "Aug 01, 2025"
 description: "探索图着色问题的核心算法与应用"

--- a/src/content/blog/2025-08-02/index.md
+++ b/src/content/blog/2025-08-02/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的后缀树（Suffix Tree）数据结构"
+title: "后缀树（Suffix Tree）数据结构"
 author: "杨子凡"
 date: "Aug 02, 2025"
 description: "深入解析后缀树数据结构及其高效实现"

--- a/src/content/blog/2025-08-03/index.md
+++ b/src/content/blog/2025-08-03/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的二叉堆（Binary Heap）—— 优先队列的核心引擎"
+title: "二叉堆（Binary Heap）—— 优先队列的核心引擎"
 author: "叶家炜"
 date: "Aug 03, 2025"
 description: "深入理解二叉堆与优先队列实现"

--- a/src/content/blog/2025-08-04/index.md
+++ b/src/content/blog/2025-08-04/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "叶家炜"
 date: "Aug 04, 2025"
 description: "深入解析基数排序原理与实现"

--- a/src/content/blog/2025-08-05/index.md
+++ b/src/content/blog/2025-08-05/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "王思成"
 date: "Aug 05, 2025"
 description: "深入解析基数排序算法原理与实现"

--- a/src/content/blog/2025-08-09/index.md
+++ b/src/content/blog/2025-08-09/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的红黑树（Red-Black Tree）数据结构"
+title: "红黑树（Red-Black Tree）数据结构"
 author: "杨子凡"
 date: "Aug 09, 2025"
 description: "深入解析红黑树原理与实现"

--- a/src/content/blog/2025-08-10/index.md
+++ b/src/content/blog/2025-08-10/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数树（Radix Tree）数据结构"
+title: "基数树（Radix Tree）数据结构"
 author: "王思成"
 date: "Aug 10, 2025"
 description: "深入解析基数树原理与实现"

--- a/src/content/blog/2025-08-11/index.md
+++ b/src/content/blog/2025-08-11/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的红黑树（Red-Black Tree）数据结构"
+title: "红黑树（Red-Black Tree）数据结构"
 author: "杨岢瑞"
 date: "Aug 11, 2025"
 description: "红黑树原理与实现：自平衡二叉搜索树详解"

--- a/src/content/blog/2025-08-12/index.md
+++ b/src/content/blog/2025-08-12/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的布谷鸟哈希（Cuckoo Hashing）数据结构"
+title: "布谷鸟哈希（Cuckoo Hashing）数据结构"
 author: "黄梓淳"
 date: "Aug 12, 2025"
 description: "深入解析布谷鸟哈希原理与实现"

--- a/src/content/blog/2025-08-13/index.md
+++ b/src/content/blog/2025-08-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的布隆过滤器(Bloom Filter)数据结构"
+title: "布隆过滤器(Bloom Filter)数据结构"
 author: "王思成"
 date: "Aug 13, 2025"
 description: "深入解析布隆过滤器的原理与实现"

--- a/src/content/blog/2025-08-15/index.md
+++ b/src/content/blog/2025-08-15/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的计数排序（Counting Sort）算法"
+title: "计数排序（Counting Sort）算法"
 author: "马浩琨"
 date: "Aug 15, 2025"
 description: "探索计数排序原理与实现"

--- a/src/content/blog/2025-08-16/index.md
+++ b/src/content/blog/2025-08-16/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 A*寻路算法"
+title: "A*寻路算法"
 author: "杨其臻"
 date: "Aug 16, 2025"
 description: "深入解析 A* 寻路算法原理与代码实现"

--- a/src/content/blog/2025-08-26/index.md
+++ b/src/content/blog/2025-08-26/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的快速排序（Quick Sort）算法"
+title: "快速排序（Quick Sort）算法"
 author: "马浩琨"
 date: "Aug 26, 2025"
 description: "快速排序算法原理与实现详解"

--- a/src/content/blog/2025-08-27/index.md
+++ b/src/content/blog/2025-08-27/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的循环缓冲区（Circular Buffer）数据结构"
+title: "循环缓冲区（Circular Buffer）数据结构"
 author: "王思成"
 date: "Aug 27, 2025"
 description: "循环缓冲区原理与 C 语言实现详解"

--- a/src/content/blog/2025-08-28/index.md
+++ b/src/content/blog/2025-08-28/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的归并排序（Merge Sort）算法"
+title: "归并排序（Merge Sort）算法"
 author: "杨其臻"
 date: "Aug 29, 2025"
 description: "深入理解归并排序算法实现"

--- a/src/content/blog/2025-08-31/index.md
+++ b/src/content/blog/2025-08-31/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的堆排序（Heap Sort）算法"
+title: "堆排序（Heap Sort）算法"
 author: "马浩琨"
 date: "Aug 31, 2025"
 description: "深入理解堆排序算法原理与实现"

--- a/src/content/blog/2025-09-01/index.md
+++ b/src/content/blog/2025-09-01/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的插入排序（Insertion Sort）算法"
+title: "插入排序（Insertion Sort）算法"
 author: "黄京"
 date: "Sep 01, 2025"
 description: "深入理解并实现插入排序算法"

--- a/src/content/blog/2025-09-03/index.md
+++ b/src/content/blog/2025-09-03/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的桶排序（Bucket Sort）算法"
+title: "桶排序（Bucket Sort）算法"
 author: "黄梓淳"
 date: "Sep 03, 2025"
 description: "深入理解桶排序算法原理与实现"

--- a/src/content/blog/2025-09-04/index.md
+++ b/src/content/blog/2025-09-04/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的循环链表（Circular Linked List）数据结构"
+title: "循环链表（Circular Linked List）数据结构"
 author: "黄梓淳"
 date: "Sep 04, 2025"
 description: "深入理解循环链表数据结构"

--- a/src/content/blog/2025-09-06/index.md
+++ b/src/content/blog/2025-09-06/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的冒泡排序（Bubble Sort）算法"
+title: "冒泡排序（Bubble Sort）算法"
 author: "杨其臻"
 date: "Sep 06, 2025"
 description: "深入理解冒泡排序算法"

--- a/src/content/blog/2025-09-08/index.md
+++ b/src/content/blog/2025-09-08/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的希尔排序（Shell Sort）算法"
+title: "希尔排序（Shell Sort）算法"
 author: "黄梓淳"
 date: "Sep 08, 2025"
 description: "深入理解希尔排序算法实现"

--- a/src/content/blog/2025-09-09/index.md
+++ b/src/content/blog/2025-09-09/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的链表（Linked List）数据结构"
+title: "链表（Linked List）数据结构"
 author: "叶家炜"
 date: "Sep 09, 2025"
 description: "链表原理与实现详解"

--- a/src/content/blog/2025-09-10/index.md
+++ b/src/content/blog/2025-09-10/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的循环链表（Circular Linked List）数据结构"
+title: "循环链表（Circular Linked List）数据结构"
 author: "马浩琨"
 date: "Sep 10, 2025"
 description: "深入理解循环链表数据结构"

--- a/src/content/blog/2025-09-11/index.md
+++ b/src/content/blog/2025-09-11/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的栈（Stack）数据结构"
+title: "栈（Stack）数据结构"
 author: "李睿远"
 date: "Sep 11, 2025"
 description: "栈数据结构理论实现与应用"

--- a/src/content/blog/2025-09-13/index.md
+++ b/src/content/blog/2025-09-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的循环队列（Circular Queue）数据结构"
+title: "循环队列（Circular Queue）数据结构"
 author: "马浩琨"
 date: "Sep 13, 2025"
 description: "循环队列实现与空间优化"

--- a/src/content/blog/2025-09-14/index.md
+++ b/src/content/blog/2025-09-14/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的哈希表数据结构"
+title: "哈希表数据结构"
 author: "马浩琨"
 date: "Sep 14, 2025"
 description: "哈希表实现与性能分析"

--- a/src/content/blog/2025-09-15/index.md
+++ b/src/content/blog/2025-09-15/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "黄梓淳"
 date: "Sep 15, 2025"
 description: "深入理解基数排序算法原理"

--- a/src/content/blog/2025-09-16/index.md
+++ b/src/content/blog/2025-09-16/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的平衡二叉树（Balanced Binary Tree）数据结构"
+title: "平衡二叉树（Balanced Binary Tree）数据结构"
 author: "黄京"
 date: "Sep 16, 2025"
 description: "AVL 树实现与平衡操作详解"

--- a/src/content/blog/2025-09-18/index.md
+++ b/src/content/blog/2025-09-18/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的自动微分（Automatic Differentiation）算法"
+title: "自动微分（Automatic Differentiation）算法"
 author: "杨其臻"
 date: "Sep 18, 2025"
 description: "深入解析自动微分原理与实现"

--- a/src/content/blog/2025-09-19/index.md
+++ b/src/content/blog/2025-09-19/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的蒙特卡洛方法（Monte Carlo Method）"
+title: "蒙特卡洛方法（Monte Carlo Method）"
 author: "杨其臻"
 date: "Sep 19, 2025"
 description: "蒙特卡洛方法理论及 Python 实战"

--- a/src/content/blog/2025-09-21/index.md
+++ b/src/content/blog/2025-09-21/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 JSON 解析器"
+title: "JSON 解析器"
 author: "黄京"
 date: "Sep 21, 2025"
 description: "手把手实现 JSON 解析器"

--- a/src/content/blog/2025-09-27/index.md
+++ b/src/content/blog/2025-09-27/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 HTTP/3 协议核心机制"
+title: "HTTP/3 协议核心机制"
 author: "马浩琨"
 date: "Sep 27, 2025"
 description: "深入解析 HTTP/3 核心机制与实现"

--- a/src/content/blog/2025-09-30/index.md
+++ b/src/content/blog/2025-09-30/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的霍夫曼编码（Huffman Coding）算法"
+title: "霍夫曼编码（Huffman Coding）算法"
 author: "黄梓淳"
 date: "Sep 30, 2025"
 description: "深入理解霍夫曼编码算法"

--- a/src/content/blog/2025-10-01/index.md
+++ b/src/content/blog/2025-10-01/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的二分查找（Binary Search）算法"
+title: "二分查找（Binary Search）算法"
 author: "王思成"
 date: "Oct 01, 2025"
 description: "深入解析二分查找算法实现"

--- a/src/content/blog/2025-10-02/index.md
+++ b/src/content/blog/2025-10-02/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的信号量（Semaphore）机制"
+title: "信号量（Semaphore）机制"
 author: "杨岢瑞"
 date: "Oct 02, 2025"
 description: "深入理解并实现信号量机制"

--- a/src/content/blog/2025-10-04/index.md
+++ b/src/content/blog/2025-10-04/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的双向文本（BiDirectional Text）处理机制"
+title: "双向文本（BiDirectional Text）处理机制"
 author: "叶家炜"
 date: "Oct 04, 2025"
 description: "双向文本处理与 Unicode 算法实现"

--- a/src/content/blog/2025-10-05/index.md
+++ b/src/content/blog/2025-10-05/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "马浩琨"
 date: "Oct 06, 2025"
 description: "深入解析基数排序原理与实现"

--- a/src/content/blog/2025-10-06/index.md
+++ b/src/content/blog/2025-10-06/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 XMPP 协议服务器"
+title: "XMPP 协议服务器"
 author: "黄梓淳"
 date: "Oct 06, 2025"
 description: "深入理解并实现 XMPP 服务器"

--- a/src/content/blog/2025-10-08/index.md
+++ b/src/content/blog/2025-10-08/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的管道操作符（Pipe Operator）原理与实现"
+title: "管道操作符（Pipe Operator）原理与实现"
 author: "黄梓淳"
 date: "Oct 08, 2025"
 description: "JavaScript 管道操作符原理与实现"

--- a/src/content/blog/2025-10-10/index.md
+++ b/src/content/blog/2025-10-10/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的深度优先搜索（DFS）算法"
+title: "深度优先搜索（DFS）算法"
 author: "杨岢瑞"
 date: "Oct 10, 2025"
 description: "深度优先搜索的核心思想与实现"

--- a/src/content/blog/2025-10-11/index.md
+++ b/src/content/blog/2025-10-11/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "叶家炜"
 date: "Oct 11, 2025"
 description: "基数排序算法详解与实现"

--- a/src/content/blog/2025-10-12/index.md
+++ b/src/content/blog/2025-10-12/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的管道操作符（Pipe Operator）原理与实现"
+title: "管道操作符（Pipe Operator）原理与实现"
 author: "杨岢瑞"
 date: "Oct 12, 2025"
 description: "管道操作符原理与实现解析"

--- a/src/content/blog/2025-10-13/index.md
+++ b/src/content/blog/2025-10-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 JIT 编译器原理与优化"
+title: "JIT 编译器原理与优化"
 author: "杨子凡"
 date: "Oct 13, 2025"
 description: "深入实现 JIT 编译器原理与优化"

--- a/src/content/blog/2025-10-14/index.md
+++ b/src/content/blog/2025-10-14/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的模数转换器（ADC）原理与实现"
+title: "模数转换器（ADC）原理与实现"
 author: "黄京"
 date: "Oct 14, 2025"
 description: "深入理解 ADC 原理与实现"

--- a/src/content/blog/2025-10-15/index.md
+++ b/src/content/blog/2025-10-15/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的垃圾回收（Garbage Collection）机制"
+title: "垃圾回收（Garbage Collection）机制"
 author: "李睿远"
 date: "Oct 15, 2025"
 description: "理解垃圾回收机制并实践实现"

--- a/src/content/blog/2025-10-16/index.md
+++ b/src/content/blog/2025-10-16/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 IPv6 协议栈"
+title: "IPv6 协议栈"
 author: "李睿远"
 date: "Oct 16, 2025"
 description: "从数据包结构到代码实现"

--- a/src/content/blog/2025-10-17/index.md
+++ b/src/content/blog/2025-10-17/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "杨子凡"
 date: "Oct 18, 2025"
 description: "基数排序原理与代码实现详解"

--- a/src/content/blog/2025-10-19/index.md
+++ b/src/content/blog/2025-10-19/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的拓扑排序算法"
+title: "拓扑排序算法"
 author: "李睿远"
 date: "Oct 19, 2025"
 description: "拓扑排序算法原理与 Python 实现"

--- a/src/content/blog/2025-10-20/index.md
+++ b/src/content/blog/2025-10-20/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的信号量（Semaphore）机制"
+title: "信号量（Semaphore）机制"
 author: "杨岢瑞"
 date: "Oct 20, 2025"
 description: "信号量机制原理与实现详解"

--- a/src/content/blog/2025-10-21/index.md
+++ b/src/content/blog/2025-10-21/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 Merkle 树数据结构"
+title: "Merkle 树数据结构"
 author: "王思成"
 date: "Oct 21, 2025"
 description: "Merkle 树原理与 Python 实现"

--- a/src/content/blog/2025-10-22/index.md
+++ b/src/content/blog/2025-10-22/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的哈希表数据结构"
+title: "哈希表数据结构"
 author: "黄梓淳"
 date: "Oct 22, 2025"
 description: "哈希表原理与 Python 实现"

--- a/src/content/blog/2025-10-23/index.md
+++ b/src/content/blog/2025-10-23/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 CRDT（无冲突复制数据类型）数据结构"
+title: "CRDT（无冲突复制数据类型）数据结构"
 author: "马浩琨"
 date: "Oct 23, 2025"
 description: "深入解析 CRDT 实现无冲突数据同步"

--- a/src/content/blog/2025-10-24/index.md
+++ b/src/content/blog/2025-10-24/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "叶家炜"
 date: "Oct 24, 2025"
 description: "基数排序原理与实现详解"

--- a/src/content/blog/2025-10-25/index.md
+++ b/src/content/blog/2025-10-25/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的信号量（Semaphore）机制"
+title: "信号量（Semaphore）机制"
 author: "杨岢瑞"
 date: "Oct 25, 2025"
 description: "深入理解信号量原理与应用"

--- a/src/content/blog/2025-10-26/index.md
+++ b/src/content/blog/2025-10-26/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的脚本语言解释器"
+title: "脚本语言解释器"
 author: "杨子凡"
 date: "Oct 26, 2025"
 description: "构建迷你脚本语言解释器指南"

--- a/src/content/blog/2025-10-28/index.md
+++ b/src/content/blog/2025-10-28/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的深度优先搜索（DFS）算法"
+title: "深度优先搜索（DFS）算法"
 author: "杨其臻"
 date: "Oct 28, 2025"
 description: "深度优先搜索算法原理与实现"

--- a/src/content/blog/2025-10-29/index.md
+++ b/src/content/blog/2025-10-29/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的垃圾回收（Garbage Collection）机制"
+title: "垃圾回收（Garbage Collection）机制"
 author: "王思成"
 date: "Oct 29, 2025"
 description: "实现标记-清除垃圾回收机制"

--- a/src/content/blog/2025-10-30/index.md
+++ b/src/content/blog/2025-10-30/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的异步 I/O 机制"
+title: "异步 I/O 机制"
 author: "黄京"
 date: "Oct 30, 2025"
 description: "异步 I/O 原理与 Reactor 模式实现"

--- a/src/content/blog/2025-10-31/index.md
+++ b/src/content/blog/2025-10-31/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的信号量（Semaphore）机制"
+title: "信号量（Semaphore）机制"
 author: "李睿远"
 date: "Oct 31, 2025"
 description: "深入信号量原理与代码实现"

--- a/src/content/blog/2025-11-01/index.md
+++ b/src/content/blog/2025-11-01/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的哈希表数据结构"
+title: "哈希表数据结构"
 author: "黄京"
 date: "Nov 01, 2025"
 description: "哈希表原理与实现详解"

--- a/src/content/blog/2025-11-02/index.md
+++ b/src/content/blog/2025-11-02/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的信号量（Semaphore）机制"
+title: "信号量（Semaphore）机制"
 author: "杨岢瑞"
 date: "Nov 02, 2025"
 description: "信号量机制原理与实现"

--- a/src/content/blog/2025-11-03/index.md
+++ b/src/content/blog/2025-11-03/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "杨其臻"
 date: "Nov 03, 2025"
 description: "深入解析基数排序原理与实现"

--- a/src/content/blog/2025-11-04/index.md
+++ b/src/content/blog/2025-11-04/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的布隆过滤器（Bloom Filter）数据结构"
+title: "布隆过滤器（Bloom Filter）数据结构"
 author: "王思成"
 date: "Nov 04, 2025"
 description: "布隆过滤器原理与实现"

--- a/src/content/blog/2025-11-05/index.md
+++ b/src/content/blog/2025-11-05/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的动态脚本执行引擎"
+title: "动态脚本执行引擎"
 author: "王思成"
 date: "Nov 05, 2025"
 description: "从零实现动态脚本引擎"

--- a/src/content/blog/2025-11-07/index.md
+++ b/src/content/blog/2025-11-07/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的队列（Queue）数据结构"
+title: "队列（Queue）数据结构"
 author: "李睿远"
 date: "Nov 07, 2025"
 description: "队列数据结构详解与实现"

--- a/src/content/blog/2025-11-08/index.md
+++ b/src/content/blog/2025-11-08/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 C++ 移动语义（Move Semantics）"
+title: "C++ 移动语义（Move Semantics）"
 author: "黄京"
 date: "Nov 08, 2025"
 description: "C++ 移动语义核心概念与实现"

--- a/src/content/blog/2025-11-09/index.md
+++ b/src/content/blog/2025-11-09/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 CHIP-8 虚拟机"
+title: "CHIP-8 虚拟机"
 author: "李睿远"
 date: "Nov 09, 2025"
 description: "从零实现 CHIP-8 虚拟机"

--- a/src/content/blog/2025-11-10/index.md
+++ b/src/content/blog/2025-11-10/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的 Git 内部机制与核心操作"
+title: "Git 内部机制与核心操作"
 author: "马浩琨"
 date: "Nov 10, 2025"
 description: "深入 Git 内部机制与实现原理"

--- a/src/content/blog/2025-11-11/index.md
+++ b/src/content/blog/2025-11-11/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "李睿远"
 date: "Nov 11, 2025"
 description: "深入解析基数排序的原理与实现"

--- a/src/content/blog/2025-11-12/index.md
+++ b/src/content/blog/2025-11-12/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的异步编程（Async Programming）机制"
+title: "异步编程（Async Programming）机制"
 author: "黄梓淳"
 date: "Nov 12, 2025"
 description: "从异步编程到事件循环实现"

--- a/src/content/blog/2025-11-13/index.md
+++ b/src/content/blog/2025-11-13/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的基数排序（Radix Sort）算法"
+title: "基数排序（Radix Sort）算法"
 author: "杨子凡"
 date: "Nov 13, 2025"
 description: "基数排序原理与实现详解"

--- a/src/content/blog/2025-11-15/index.md
+++ b/src/content/blog/2025-11-15/index.md
@@ -1,5 +1,5 @@
 ---
-title: "基本的信号量（Semaphore）机制"
+title: "信号量（Semaphore）机制"
 author: "杨子凡"
 date: "Nov 15, 2025"
 description: "信号量机制解析与代码实现"


### PR DESCRIPTION
## Summary
- removed the leading "基本的" prefix from blog frontmatter titles
- trimmed surrounding whitespace in the updated titles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d55d344f88320bee5e6764eb1b3de)