### PR TITLE
fix: create public/blog/<post>/ before copying tex+pdf

### DIFF
--- a/scripts/make.py
+++ b/scripts/make.py
@@ -146,6 +146,7 @@ def pdfgenr(post):
                 print(f"   LaTeX failed: {post} (no PDF produced); skipping")
                 shutil.rmtree(tmp_dir, ignore_errors=True)
                 return False
+        os.makedirs(pbl_dir + post, exist_ok=True)
         shutil.copy(tmp_dir + "index.tex", pbl_dir + post + "/index.tex")
         shutil.copy(tmp_dir + "index.pdf", pbl_dir + post + "/index.pdf")
         shutil.rmtree(tmp_dir)


### PR DESCRIPTION
## Summary
- Follow-up to #28. The merged change moved the sha256 write to *after* `pdfgenr` succeeds, but that write was implicitly creating `public/blog/<post>/` via the `File` class's `os.makedirs` side effect.
- Without it, the first new post (2026-02-15) crashes the publish job again:

  ```
  FileNotFoundError: [Errno 2] No such file or directory: './public/blog/2026-02-15/index.tex'
  ```
- Fix: have `pdfgenr` create the destination directory explicitly so neither code path depends on `File()`'s side effect.
- Confirmed in the failed run that the resilience change from #28 is working — `2026-02-13` now logs `LaTeX failed: 2026-02-13 (no PDF produced); skipping` instead of crashing. This second failure is a regression I introduced; this PR closes it.

## Test plan
- [ ] Re-run `Generate New Article` (or wait for the next scheduled trigger).
- [ ] Confirm `2026-02-13` is logged as a skip and `2026-02-15` onward compile and commit.