### PR TITLE
fix: skip monthly batch when a member post failed to compile

### DIFF
--- a/scripts/make.py
+++ b/scripts/make.py
@@ -211,6 +211,11 @@ def batch():
                         else:
                                 print(f"    Removing obsolete: {bch_id} #{existing_hsh} -> #{hsh}")
                                 os.remove(f"{bch_dir}compilation_{bch_id}_{existing_hsh}.pdf")
+                # Skip batches that include a post whose individual compile failed
+                missing = [posts[i] for i in bch_range if not os.path.exists(f"{pbl_dir}{posts[i]}/index.tex")]
+                if missing:
+                        print(f"      Skipping batch: {bch_id} #{hsh} (missing tex for {', '.join(missing)})")
+                        continue
                 print(f"     Processing batch: {bch_id} #{hsh}")
                 filename = f"compilation_{bch_id}_{hsh}"
                 # Writing index.tex to be compiled
@@ -225,6 +230,10 @@ def batch():
                 ])
                 # Compiling and cleaning
                 texcomp("drvmly.ltx")
+                if not os.path.exists(tmp_dir + "index.pdf"):
+                        print(f"   LaTeX failed for batch: {bch_id}; skipping")
+                        shutil.rmtree(tmp_dir, ignore_errors=True)
+                        continue
                 shutil.copy(tmp_dir + "index.pdf", bch_dir + filename.lower() + ".pdf")
                 shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION
## Summary
- Follow-up to #28 / #29. The publish step now correctly skips posts whose LaTeX failed (`2026-02-13`), so per-post compile no longer crashes the job.
- The `batch()` step still does, because it reads `public/blog/<post>/index.tex` for every post in a 5-post window:

  ```
  FileNotFoundError: [Errno 2] No such file or directory: './public/blog/2026-02-13/index.tex'
  ```
  This drops batch 57 (which contains 2026-02-13) and everything after it.
- Fix: before processing a batch, check that every member post has an `index.tex`; if not, log and skip the batch. Also bail gracefully if lualatex itself produces no PDF for a batch (same pattern as the per-post fix).
- When 2026-02-13 eventually compiles successfully (markdown change → batch hash change), the batch will be regenerated on the next run.

## Test plan
- [ ] Re-run `Generate New Article` (or wait for the next scheduled trigger).
- [ ] Confirm batch 57 logs `Skipping batch: 57 ... (missing tex for 2026-02-13)` and the job reaches **Commit and Push Changes**.
- [ ] Confirm batches 58+ (if any) are processed.