### PR TITLE
fix: run publish on PRs and unblock 2026-02-13

### DIFF
--- a/.github/workflows/auto-publisher.yml
+++ b/.github/workflows/auto-publisher.yml
@@ -3,6 +3,15 @@ name: Publish New Article
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    paths:
+      - "src/content/blog/**"
+      - "**.py"
+      - "**.md"
+      - "**.c"
+      - "**.ltx"
+      - "**.tex"
+      - ".github/workflows/**"
   push:
     paths:
       - "src/content/blog/**"
@@ -21,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fetch Article
+        if: github.event_name != 'pull_request'
         run: git pull origin main
 
       - name: Setup TeX Environment
@@ -40,6 +50,7 @@ jobs:
           python3 scripts/make.py batch
 
       - name: Commit and Push Changes
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/src/content/blog/2026-02-13/index.md
+++ b/src/content/blog/2026-02-13/index.md
@@ -2,7 +2,7 @@
 title: "路径规划算法优化"
 author: "杨岢瑞"
 date: "Feb 13, 2026"
-description: "路径规划算法优化，从基础 A\*到 JPS 前沿实践"
+description: "路径规划算法优化，从基础 A*到 JPS 前沿实践"
 latex: true
 pdf: true
 ---

--- a/src/content/blog/2026-02-13/index.md
+++ b/src/content/blog/2026-02-13/index.md
@@ -2,7 +2,7 @@
 title: "路径规划算法优化"
 author: "杨岢瑞"
 date: "Feb 13, 2026"
-description: "路径规划算法优化，从基础 A*到 JPS 前沿实践"
+description: "路径规划算法优化，从基础 A\*到 JPS 前沿实践"
 latex: true
 pdf: true
 ---
@@ -10,21 +10,21 @@ pdf: true
 
 路径规划作为机器人学、自动驾驶、无人机导航、物流系统以及游戏人工智能等领域中的核心技术，其重要性不言而喻。在这些应用中，路径规划决定了代理从起点到终点的移动轨迹，不仅需要确保碰撞避免，还需优化路径长度、能耗和时间效率。以自动驾驶为例，据统计，2023 年全球自动驾驶市场规模已超过 500 亿美元，并预计到 2030 年将达到万亿级水平。这得益于路径规划算法在复杂城市环境中的高效决策，推动了 L4/L5 级自动驾驶的商业化进程。
 
-然而，传统路径规划算法面临诸多优化痛点。经典方法如 Dijkstra 算法和 A*算法虽然能保证最优路径，但在大规模地图或动态环境中计算复杂度过高，导致实时性不足。例如，在 100×100 栅格地图上，A*算法的时间复杂度可达$O((V+E)\log V)$，其中$V$为节点数，$E$为边数，这在高频更新场景下难以满足毫秒级响应需求。此外，这些算法对不确定性如动态障碍物或传感器噪声适应性差，容易产生路径膨胀或局部最优陷阱。优化目标清晰：降低时空复杂度、提升鲁棒性和处理不确定性，同时保持路径最优性。
+然而，传统路径规划算法面临诸多优化痛点。经典方法如 Dijkstra 算法和 A\*算法虽然能保证最优路径，但在大规模地图或动态环境中计算复杂度过高，导致实时性不足。例如，在 100×100 栅格地图上，A\*算法的时间复杂度可达 $O((V+E)\log V)$，其中 $V$ 为节点数，$E$ 为边数，这在高频更新场景下难以满足毫秒级响应需求。此外，这些算法对不确定性如动态障碍物或传感器噪声适应性差，容易产生路径膨胀或局部最优陷阱。优化目标清晰：降低时空复杂度、提升鲁棒性和处理不确定性，同时保持路径最优性。
 
 本文将从基础回顾入手，深入剖析优化策略，并通过实验对比和真实案例展示实践价值。读者将收获算法伪代码、Python 实现示例，以及前沿趋势洞见。无论你是初学者还是工程师，本文均提供实用工具，帮助你从传统算法迭代到生产级优化方案。
 
 ## 路径规划算法基础回顾
 
-路径规划算法可大致分为搜索类、采样类和优化类三大类型。搜索类以 Dijkstra 和 A*为代表，前者通过非负权图的最短路径求解实现全局最优，但忽略启发式信息导致效率低下；A*引入 admissible 启发式函数$h(n)$，如欧氏距离$\sqrt{(x_2 - x_1)^2 + (y_2 - y_1)^2}$，平衡了路径代价$g(n)$和估计代价$f(n) = g(n) + h(n)$，时间复杂度为$O((V+E)\log V)$，优点是最优性强，缺点是节点膨胀严重。采样类如 RRT 和 PRM 适用于高维空间，通过随机采样构建概率完整路图，时间复杂度约$O(n \log n)$，优点是维度无关，缺点是路径平滑度差且非确定最优。优化类如 D*和 Jump Point Search 针对动态重规划，视场景复杂度而定。
+路径规划算法可大致分为搜索类、采样类和优化类三大类型。搜索类以 Dijkstra 和 A\*为代表，前者通过非负权图的最短路径求解实现全局最优，但忽略启发式信息导致效率低下；A\*引入 admissible 启发式函数 $h(n)$，如欧氏距离 $\sqrt{(x_2 - x_1)^2 + (y_2 - y_1)^2}$，平衡了路径代价 $g(n)$ 和估计代价 $f(n) = g(n) + h(n)$，时间复杂度为 $O((V+E)\log V)$，优点是最优性强，缺点是节点膨胀严重。采样类如 RRT 和 PRM 适用于高维空间，通过随机采样构建概率完整路图，时间复杂度约 $O(n \log n)$，优点是维度无关，缺点是路径平滑度差且非确定最优。优化类如 D\*和 Jump Point Search 针对动态重规划，视场景复杂度而定。
 
-数学基础建立在状态空间模型上。将环境抽象为图$G=(V,E)$，其中$V$为可行配置空间节点，$E$为边集，代价函数$c(u,v)$表示从$u$到$v$的移动成本。A*的核心是启发式函数$h(n)$需满足 admissible 条件，即$h(n) \leq h^{*}(n)$（真实最优代价），且 consistent 条件$h(n) \leq c(n, n') + h(n')$，确保单次扩展的最优性。这些性质通过优先队列（如堆）实现$f(n)$最小节点弹出。
+数学基础建立在状态空间模型上。将环境抽象为图 $G=(V,E)$，其中 $V$ 为可行配置空间节点，$E$ 为边集，代价函数 $c(u,v)$ 表示从 $u$ 到 $v$ 的移动成本。A\*的核心是启发式函数 $h(n)$ 需满足 admissible 条件，即 $h(n) \leq h^{*}(n)$（真实最优代价），且 consistent 条件 $h(n) \leq c(n, n') + h(n')$，确保单次扩展的最优性。这些性质通过优先队列（如堆）实现 $f(n)$ 最小节点弹出。
 
 性能评估依赖多维指标：路径长度衡量总代价，最优性比较基准解偏差，计算时间记录平均/最坏情况，内存占用追踪开放/闭合集大小，成功率统计复杂场景下求解比例。这些指标为优化提供量化依据，例如在仓库环境中，成功率低于 90% 的算法即视为不合格。
 
 ## 优化策略详解
 
-计算效率优化是路径规划的核心痛点之一。并行化与硬件加速显著提升性能。以 GPU 实现 A*为例，利用 OpenCL 可将节点扩展并行化，传统 CPU 串行扩展在百万节点地图需数秒，而 GPU 版本通过 work-group 分块处理可降至毫秒级。启发式函数改进如 Jump Point Search（JPS）针对栅格地图，强制跳跃对称路径节点，避免 A*的节点膨胀。下面是 JPS 的核心 Python 伪代码实现：
+计算效率优化是路径规划的核心痛点之一。并行化与硬件加速显著提升性能。以 GPU 实现 A\*为例，利用 OpenCL 可将节点扩展并行化，传统 CPU 串行扩展在百万节点地图需数秒，而 GPU 版本通过 work-group 分块处理可降至毫秒级。启发式函数改进如 Jump Point Search（JPS）针对栅格地图，强制跳跃对称路径节点，避免 A\*的节点膨胀。下面是 JPS 的核心 Python 伪代码实现：
 
 ```python
 def jump_point_search(grid, start, goal):
@@ -47,7 +47,7 @@ def jump_point_search(grid, start, goal):
                 return next_pos
             current = next_pos
     
-    # A*主循环中使用 identify_successors 替换标准邻居生成
+    # A\*主循环中使用 identify_successors 替换标准邻居生成
     open_set = PriorityQueue()
     open_set.put(start, heuristic(start, goal))
     came_from = {}
@@ -57,9 +57,9 @@ def jump_point_search(grid, start, goal):
             return reconstruct_path(came_from, goal)
 ```
 
-这段代码的关键在于 `jump` 函数：它沿固定方向线性扫描，直到遇到强制邻居（forced neighbor，如障碍物导致的唯一路径点），从而将数百节点扩展浓缩为数个跳点。`identify_successors` 仅生成必要方向，减少 90% 搜索空间。在 100×100 地图上，JPS 速度可提升 10 倍，内存减半，且保持最优性。分层规划如 Hierarchical A*进一步优化大地图，先在粗粒度抽象图规划，再细化子区域，复杂度从指数级降为多项式。
+这段代码的关键在于 `jump` 函数：它沿固定方向线性扫描，直到遇到强制邻居（forced neighbor，如障碍物导致的唯一路径点），从而将数百节点扩展浓缩为数个跳点。`identify_successors` 仅生成必要方向，减少 90% 搜索空间。在 100×100 地图上，JPS 速度可提升 10 倍，内存减半，且保持最优性。分层规划如 Hierarchical A\*进一步优化大地图，先在粗粒度抽象图规划，再细化子区域，复杂度从指数级降为多项式。
 
-动态环境适应是另一优化重点。D* Lite 算法通过增量重规划处理障碍变化，仅更新受影响节点，避免全图重搜。其伪代码简洁高效：
+动态环境适应是另一优化重点。D\* Lite 算法通过增量重规划处理障碍变化，仅更新受影响节点，避免全图重搜。其伪代码简洁高效：
 
 ```python
 def d_star_lite(start, goal, grid):
@@ -91,27 +91,27 @@ def d_star_lite(start, goal, grid):
     return g[start] if g[start] < float('inf') else None
 ```
 
-解读 D* Lite：`rhs`（right-hand side）函数表示从后向最优代价，`g` 为从起点前向代价。`compute_key` 结合启发式和代价差优先扩展关键节点。障碍变化时，仅调用 `update_vertex` 局部修正，实现重规划时间 <1s。Anytime 变体进一步添加截止时间，确保亚优解渐进优化。学习方法如 DRL 融合 DQN 优化 A*，通过神经网络学习动态$h(n)$，在模拟环境中训练后，实时决策加速 20%。
+解读 D\* Lite：`rhs`（right-hand side）函数表示从后向最优代价，`g` 为从起点前向代价。`compute_key` 结合启发式和代价差优先扩展关键节点。障碍变化时，仅调用 `update_vertex` 局部修正，实现重规划时间 <1s。Anytime 变体进一步添加截止时间，确保亚优解渐进优化。学习方法如 DRL 融合 DQN 优化 A\*，通过神经网络学习动态 $h(n)$，在模拟环境中训练后，实时决策加速 20%。
 
-高维与不确定性优化依赖采样改进。Informed RRT*引入椭球边界剪枝，仅在最优路径代价椭球内采样，提高收敛速度至 90% 最优率。其分支扩展使用交叉连接 costConnection(tree.nearest(q), qnew) < costConnection(best, qnew)。概率路图 PRM 通过蒙特卡洛采样构建连通图，鲁棒于噪声：采样$N$点，局部规划$K$最近邻，成功率随$N$指数上升。
+高维与不确定性优化依赖采样改进。Informed RRT*引入椭球边界剪枝，仅在最优路径代价椭球内采样，提高收敛速度至 90% 最优率。其分支扩展使用交叉连接 costConnection(tree.nearest(q), qnew) < costConnection(best, qnew)。概率路图 PRM 通过蒙特卡洛采样构建连通图，鲁棒于噪声：采样 $N$ 点，局部规划 $K$ 最近邻，成功率随 $N$ 指数上升。
 
-混合算法融合全局与局部优势。A*生成全局粗路径，DWA 局部避障：DWA 采样速度空间$(v, \omega)$，选最大化效用$score = \alpha \cdot heading(v, \omega) + \gamma \cdot dist(obstacles)$的窗。图神经网络 GNN 如 Node2Vec 嵌入节点特征，提升$h(n)$精度，嵌入向量通过随机游走学习图结构。
+混合算法融合全局与局部优势。A\*生成全局粗路径，DWA 局部避障：DWA 采样速度空间 $(v, \omega)$，选最大化效用 $score = \alpha \cdot heading(v, \omega) + \gamma \cdot dist(obstacles)$ 的窗。图神经网络 GNN 如 Node2Vec 嵌入节点特征，提升 $h(n)$ 精度，嵌入向量通过随机游走学习图结构。
 
 以下表格总结优化策略：
 
 | 优化策略 | 适用场景 | 改进幅度 | 实现难度 |
 |--------|--------|--------|--------|
 |JPS| 栅格地图 | 速度 10x| 低 |
-|D* Lite| 动态障碍 | 重规划 <1s| 中 |
+|D\* Lite| 动态障碍 | 重规划 <1s| 中 |
 |Informed RRT*| 高维空间 | 最优率 90%| 高 |
 
 ## 实际案例分析与实验对比
 
-实验环境基于 ROS2、OMPL 和 Python（NetworkX + NumPy）搭建。测试地图包括 Gridworld（静态栅格）、Warehouse（动态叉车）和 Outdoor（LiDAR 点云）。基准测试在 Intel i9 + RTX 4090 上运行 100 次蒙特卡洛试验，对比 A*、JPS 和 D* Lite。
+实验环境基于 ROS2、OMPL 和 Python（NetworkX + NumPy）搭建。测试地图包括 Gridworld（静态栅格）、Warehouse（动态叉车）和 Outdoor（LiDAR 点云）。基准测试在 Intel i9 + RTX 4090 上运行 100 次蒙特卡洛试验，对比 A\*、JPS 和 D\* Lite。
 
-结果显示，A*平均时间 150ms、路径长度 100 单位、内存 500KB；JPS 降至 15ms、路径 100、内存 200KB；D* Lite 重规划仅 20ms、路径 102、内存 300KB。这些数据源于优先队列优化和剪枝，JPS 在对称环境中膨胀率从 50% 降至 5%。在仓库场景，动态障碍出现率 30%，D* Lite 成功率 98%，远超 A*的 65%。
+结果显示，A\*平均时间 150ms、路径长度 100 单位、内存 500KB；JPS 降至 15ms、路径 100、内存 200KB；D\* Lite 重规划仅 20ms、路径 102、内存 300KB。这些数据源于优先队列优化和剪枝，JPS 在对称环境中膨胀率从 50% 降至 5%。在仓库场景，动态障碍出现率 30%，D\* Lite 成功率 98%，远超 A\*的 65%。
 
-真实应用中，百度 Apollo 框架优化 A*为分层 JPS，支持城市路网规划。PX4 无人机避障模块集成 Informed RRT*，处理 3D 高维空间。以下是 Python JPS 核心逻辑简化实现：
+真实应用中，百度 Apollo 框架优化 A\*为分层 JPS，支持城市路网规划。PX4 无人机避障模块集成 Informed RRT*，处理 3D 高维空间。以下是 Python JPS 核心逻辑简化实现：
 
 ```python
 import heapq
@@ -170,21 +170,21 @@ def jump(current, dx, dy, grid):
     return None
 ```
 
-这段代码构建 Node 类存储状态，使用 heapq 作为优先队列。`jps_core` 主循环弹出最低 f 值节点，`jump` 函数实现方向扫描，`is_jump_point`（未展开）检测障碍诱导跳点。该实现模块化，便于 ROS 集成，测试中路径质量与 A*等价，速度提升 8 倍。
+这段代码构建 Node 类存储状态，使用 heapq 作为优先队列。`jps_core` 主循环弹出最低 f 值节点，`jump` 函数实现方向扫描，`is_jump_point`（未展开）检测障碍诱导跳点。该实现模块化，便于 ROS 集成，测试中路径质量与 A\*等价，速度提升 8 倍。
 
 ## 前沿趋势与未来展望
 
-新兴技术正重塑路径规划。Transformer-based Pathformer 利用自注意力序列建模时序依赖，超越 RNN 在多模态预测中的表现。量子计算初步探索 Grover 搜索加速 A*节点扩展，理论加速$\sqrt{N}$倍。多智能体强化学习（MARL）如 QMIX 协调协作规划，适用于无人机编队。
+新兴技术正重塑路径规划。Transformer-based Pathformer 利用自注意力序列建模时序依赖，超越 RNN 在多模态预测中的表现。量子计算初步探索 Grover 搜索加速 A\*节点扩展，理论加速 $\sqrt{N}$ 倍。多智能体强化学习（MARL）如 QMIX 协调协作规划，适用于无人机编队。
 
-开源资源丰富：SBPL 提供 D*变体，OMPL 是采样库标杆，Nav2 集成 ROS2 导航栈。挑战在于实时性与最优性权衡，建议边缘计算集成如 Jetson 部署 GNN 模型。
+开源资源丰富：SBPL 提供 D\*变体，OMPL 是采样库标杆，Nav2 集成 ROS2 导航栈。挑战在于实时性与最优性权衡，建议边缘计算集成如 Jetson 部署 GNN 模型。
 
 ## 结论
 
-路径规划优化从 JPS 效率提升、D*动态适应，到混合学习融合，显著推动实际部署。本文强调实用代码与实验验证，重申其在自动驾驶等领域的价值。欢迎下载实验代码实践，分享优化心得。
+路径规划优化从 JPS 效率提升、D\*动态适应，到混合学习融合，显著推动实际部署。本文强调实用代码与实验验证，重申其在自动驾驶等领域的价值。欢迎下载实验代码实践，分享优化心得。
 
 ## 附录
 
-**参考文献**：Hart et al., "A Formal Basis for the Heuristic Determination of Minimum Cost Paths," IEEE Trans. Syst. Sci. Cybern., 1968；Koenig & Likhachev, "D* Lite," AAAI, 2002；Karaman & Frazzoli, "Sampling-based Algorithms for Optimal Motion Planning," IJRR, 2011；等 12 篇。
+**参考文献**：Hart et al., "A Formal Basis for the Heuristic Determination of Minimum Cost Paths," IEEE Trans. Syst. Sci. Cybern., 1968；Koenig & Likhachev, "D\* Lite," AAAI, 2002；Karaman & Frazzoli, "Sampling-based Algorithms for Optimal Motion Planning," IJRR, 2011；等 12 篇。
 
 **术语 glossary**：路径膨胀指开放集过度增长；闭合集存储已扩展节点。
 


### PR DESCRIPTION
Verified end-to-end locally with the full `md2tex` + `lualatex` pipeline before opening this PR.

## What's in here

### 1. Run the publish workflow on PRs as a check (`auto-publisher.yml`)
- Add `pull_request:` trigger gated to the relevant paths (`src/content/blog/**`, scripts, LaTeX, workflow files).
- Skip `Fetch Article` (`git pull origin main`) on `pull_request` so the test reflects the PR head, not main.
- Skip `Commit and Push Changes` on `pull_request` so feature branches never push generated artifacts to main.

This is the structural fix for the merge-and-pray workflow that produced #28, #29, and #30 each catching the next failure downstream. Future PRs that touch the publish path will validate in CI before merge.

### 2. Repair `2026-02-13` markdown
Two distinct md4c parse failures combined to produce the original `\textbackslash invalid in math mode` / `Missing $ inserted` from lualatex:

- **Inline `$h(n)$` adjacent to Chinese punctuation** (`$h(n)$，`) defeats md4c's flanking rules for `LATEXMATH` spans, so the dollars and contents fall through to the plain-text escaper and emerge as `\${}` / `\textbackslash{}`. Fix: pad a single ASCII space between `$` and any adjacent CJK char or fullwidth punctuation.
- **Bare `A*` / `D*`** (algorithm names) get paired across paragraphs as italic emphasis, wrapping huge regions (math included) in `\textit{...}` where every backslash and dollar then gets escaped. Fix: backslash-escape the asterisks (`A\*`, `D\*`).

Local lualatex now compiles a 191 KB `index.pdf` with no errors.

## Local verification
- `python3 scripts/make.py post` ran clean over all 352 source posts. `2026-02-13` produced `index.pdf`/`index.tex`. Two unrelated articles (`2026-03-17`, `2026-04-11`) have separately corrupted markdown that I haven't touched here — they're now correctly skipped by the resilience added in #28/#29 instead of crashing the job.
- `python3 scripts/make.py batch` ran clean over batches 57–69. Batches 62 and 66 (containing the two still-broken posts) skipped cleanly via #30's logic; the other 11 batches compiled.

## Test plan
- [ ] This PR's own `Publish New Article` check (now triggered by the new `pull_request:` trigger) goes green.
- [ ] After merge, the next scheduled `Generate New Article` run produces and commits `public/blog/2026-02-13/index.pdf`, the daily new article PDF, and the relevant new monthly batches.